### PR TITLE
fix: Downgrade `jsr:@david/publish-on-tag` from 0.2 to 0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           deno-version: ${{ env.DENO_VERSION }}
       - name: Publish on tag
-        run: deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.2
+        run: deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.1


### PR DESCRIPTION
Cannot run `deno publish --dry-run` properly when 0.2